### PR TITLE
fix: fix exit condition in loop, to prevent infinite loop when module…

### DIFF
--- a/architect.js
+++ b/architect.js
@@ -200,7 +200,7 @@ if (typeof module === "object") (function () {
             }
         }
         else {
-            while (base) {
+            while (base !== "/") {
                 newPath = resolve(base, "node_modules", packagePath);
                 if (existsSync(newPath)) {
                     newPath = realpathSync(newPath);


### PR DESCRIPTION
When trying lo load a module synchronously, and that module doesn't exist, the loader stalls in an infinite loop, as base is never `undefined`, `null` or `""`, even when we try to go one level higher from root.
When loading the module asynchronously, the code works, as is used `/` as exit condition [here](https://github.com/c9/architect/blob/master/architect.js#L249), instead of an empty path.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Fixes https://github.com/c9/architect/issues/27, that happens again as changes in https://github.com/c9/architect/pull/43 were reverted in https://github.com/c9/architect/pull/55

This PR was already requested in https://github.com/c9/architect/pull/70 but never merged.
